### PR TITLE
Update supported data types in `TOML.print` docstring

### DIFF
--- a/src/TOML.jl
+++ b/src/TOML.jl
@@ -101,7 +101,7 @@ Writes `data` as TOML syntax to the stream `io`. The keyword argument `sort`
 sorts the output on the keys of the tables with the top level tables are
 sorted according to the keyword argument `by`.
 
-The following data types are supported: `AbstractDict`, `Integer`, `AbstractFloat`, `Bool`,
+The following data types are supported: `AbstractDict`, `AbstractVector`, `AbstractString`, `Integer`, `AbstractFloat`, `Bool`,
 `Dates.DateTime`, `Dates.Time`, `Dates.Date`. Note that the integers and floats
 need to be convertible to `Float64` and `Int64` respectively. For other data types,
 pass the function `to_toml` that takes the data types and returns a value of a


### PR DESCRIPTION
(xref pull request [#41226](https://github.com/JuliaLang/julia/pull/41226) from the `julia` repo)

`AbstractVector` and `AbstractString` are missing according to [this line](https://github.com/JuliaLang/julia/blob/bc3ce48636b700d153d2c84614aaea8cb8843d43/stdlib/TOML/src/print.jl#L54):

```julia
const TOMLValue = Union{AbstractVector, AbstractDict, Dates.DateTime, Dates.Time, Dates.Date, Bool, Integer, AbstractFloat, AbstractString}
```