### PR TITLE
Add link to stdlib TOML docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,6 @@ A [TOML v1.0.0](https://github.com/toml-lang/toml) parser for Julia.
 [![Build Status](https://github.com/JuliaLang/TOML.jl/workflows/CI/badge.svg)](https://github.com/JuliaLang/TOML.jl/actions?query=workflow%3ACI) [![codecov](https://codecov.io/gh/JuliaLang/TOML.jl/branch/master/graph/badge.svg)](https://codecov.io/gh/JuliaLang/TOML.jl)
 [![docs](https://img.shields.io/badge/docs-dev-blue.svg)](https://JuliaLang.github.io/TOML.jl/dev/)
 
-*Note:*  In Julia 1.6+, this is a standard library and does not need to be explicitly installed.
+*Note:*  In Julia 1.6+, this is a standard library and does not need to be explicitly installed. See <https://docs.julialang.org/en/v1/stdlib/TOML/> for more information.
 
 *Note:*  A different TOML package was previously hosted in this package's URL. If you have the older package (UUID `191fdcea...`) installed in your environment from `https://github.com/JuliaLang/TOML.jl.git`, `update` and other `Pkg` operations may fail. To switch to this package, remove and re-add `TOML`. The old TOML package (which only supports TOML 0.4.0) may be found in `https://github.com/JuliaAttic/TOML.jl`.


### PR DESCRIPTION
This repository is the first one which shows up when searching for `jl toml` in multiple search engines, so let's add a link to the new place.