### PR TITLE
Fix newlines around nested dicts

### DIFF
--- a/src/print.jl
+++ b/src/print.jl
@@ -158,19 +158,19 @@ function print_table(f::MbyFunc, io::IO, a::AbstractDict,
             value = to_toml_value(f, value)
         end
         if is_table(value)
+            # print table
+            first_block || println(io)
+            first_block = false
             push!(ks, String(key))
             header = isempty(value) || !all(is_tabular(v) for v in values(value))::Bool
             if header
-                # print table
-                first_block || println(io)
-                first_block = false
                 Base.print(io, ' '^4indent)
                 Base.print(io,"[")
                 printkey(io, ks)
                 Base.print(io,"]\n")
             end
             # Use runtime dispatch here since the type of value seems not to be enforced other than as AbstractDict
-            Base.invokelatest(print_table, f, io, value, ks; indent = indent + header, first_block = header, sorted=sorted, by=by)
+            Base.invokelatest(print_table, f, io, value, ks; indent = indent + header, first_block = true, sorted=sorted, by=by)
             pop!(ks)
         elseif is_array_of_tables(value)
             # print array of tables

--- a/test/print.jl
+++ b/test/print.jl
@@ -109,3 +109,12 @@ a = 2
 c = 1.345
 d = "hello"
 """
+
+@test toml_str(Dict("a" => Dict("b" => Dict("c" => 1)), "d" => Dict("e" => 2))) ==
+"""
+[a.b]
+c = 1
+
+[d]
+e = 2
+"""


### PR DESCRIPTION
On current master:
```
julia> TOML.print(Dict("a" => Dict("b" => Dict("c" => 1)), "d" => Dict("e" => 2)))

[a.b]
c = 1
[d]
e = 2
```

With this PR:
```
julia> TOML.print(Dict("a" => Dict("b" => Dict("c" => 1)), "d" => Dict("e" => 2)))
[a.b]
c = 1

[d]
e = 2
```