### PR TITLE
Allow specification of dicttype when parsing TOML

### DIFF
--- a/src/TOML.jl
+++ b/src/TOML.jl
@@ -22,64 +22,71 @@ performance if a larger number of small files are parsed.
 const Parser = Internals.Parser
 
 """
-    parsefile(f::AbstractString)
-    parsefile(p::Parser, f::AbstractString)
+    TOMLDict
 
-Parse file `f` and return the resulting table (dictionary). Throw a
-[`ParserError`](@ref) upon failure.
+Default dictionary type for TOML files. Note that in most cases one does not need to specify a different dictionary type, however [`TOML.parsefile`](@ref), and [`TOML.parse`](@ref) allow you to specify your own custom dictionary type, as long as it is <: AbstractDict{String, Any}
+"""
+const TOMLDict = Internals.TOMLDict
+
+"""
+    parsefile(f::AbstractString; dicttype)
+    parsefile(p::Parser, f::AbstractString; dicttype)
+
+Parse file `f` and return the resulting table (dictionary, or dicttype <: AbstractDict{String, Any}). Throw a
+[`ParserError`](@ref) upon failure. 
 
 See also: [`TOML.tryparsefile`](@ref)
 """
-parsefile(f::AbstractString) =
-    Internals.parse(Parser(read(f, String); filepath=abspath(f)))
-parsefile(p::Parser, f::AbstractString) =
-    Internals.parse(Internals.reinit!(p, read(f, String); filepath=abspath(f)))
+parsefile(f::AbstractString; dicttype=TOMLDict) =
+    Internals.parse(Parser(read(f, String); filepath=abspath(f), root=dicttype()))
+parsefile(p::Parser, f::AbstractString; dicttype=TOMLDict) =
+    Internals.parse(Internals.reinit!(p, read(f, String); filepath=abspath(f), root=dicttype()))
 
 """
-    tryparsefile(f::AbstractString)
-    tryparsefile(p::Parser, f::AbstractString)
+    tryparsefile(f::AbstractString; dicttype)
+    tryparsefile(p::Parser, f::AbstractString; dicttype)
 
-Parse file `f` and return the resulting table (dictionary). Return a
+Parse file `f` and return the resulting table (dictionary or dicttype <: AbstractDict{String, Any}). Return a
 [`ParserError`](@ref) upon failure.
 
 See also: [`TOML.parsefile`](@ref)
 """
-tryparsefile(f::AbstractString) =
-    Internals.tryparse(Parser(read(f, String); filepath=abspath(f)))
-tryparsefile(p::Parser, f::AbstractString) =
-    Internals.tryparse(Internals.reinit!(p, read(f, String); filepath=abspath(f)))
+tryparsefile(f::AbstractString; dicttype=TOMLDict) = 
+    Internals.tryparse(Parser(read(f, String); filepath=abspath(f), root=dicttype()))
+tryparsefile(p::Parser, f::AbstractString; dicttype=TOMLDict) = 
+    Internals.tryparse(Internals.reinit!(p, read(f, String); filepath=abspath(f), root=dicttype()))
 
 """
-    parse(x::Union{AbstractString, IO})
-    parse(p::Parser, x::Union{AbstractString, IO})
+    parse(x::Union{AbstractString, IO}; dicttype)
+    parse(p::Parser, x::Union{AbstractString, IO}; dicttype)
 
-Parse the string  or stream `x`, and return the resulting table (dictionary).
+Parse the string  or stream `x`, and return the resulting table (dictionary or dicttype <: AbstractDict{String, Any}).
 Throw a [`ParserError`](@ref) upon failure.
 
 See also: [`TOML.tryparse`](@ref)
 """
-parse(str::AbstractString) =
-    Internals.parse(Parser(String(str)))
-parse(p::Parser, str::AbstractString) =
-    Internals.parse(Internals.reinit!(p, String(str)))
-parse(io::IO) = parse(read(io, String))
-parse(p::Parser, io::IO) = parse(p, read(io, String))
+parse(str::AbstractString; dicttype=TOMLDict) =
+    Internals.parse(Parser(String(str); root=dicttype()))
+parse(p::Parser, str::AbstractString; dicttype=TOMLDict) = 
+    Internals.parse(Internals.reinit!(p, String(str); root=dicttype()))
+parse(io::IO; dicttype=TOMLDict) = parse(read(io, String); dicttype=dicttype)
+parse(p::Parser, io::IO; dicttype=TOMLDict) = parse(p, read(io, String); dicttype=dicttype)
 
 """
-    tryparse(x::Union{AbstractString, IO})
-    tryparse(p::Parser, x::Union{AbstractString, IO})
+    tryparse(x::Union{AbstractString, IO}; dicttype)
+    tryparse(p::Parser, x::Union{AbstractString, IO}; dicttype)
 
-Parse the string or stream `x`, and return the resulting table (dictionary).
+Parse the string or stream `x`, and return the resulting table (dictionary or dicttype <: AbstractDict{String, Any}).
 Return a [`ParserError`](@ref) upon failure.
 
 See also: [`TOML.parse`](@ref)
 """
-tryparse(str::AbstractString) =
-    Internals.tryparse(Parser(String(str)))
-tryparse(p::Parser, str::AbstractString) =
-    Internals.tryparse(Internals.reinit!(p, String(str)))
-tryparse(io::IO) = tryparse(read(io, String))
-tryparse(p::Parser, io::IO) = tryparse(p, read(io, String))
+tryparse(str::AbstractString; dicttype=TOMLDict) =
+    Internals.tryparse(Parser(String(str); root=dicttype()))
+tryparse(p::Parser, str::AbstractString; dicttype=TOMLDict) =
+    Internals.tryparse(Internals.reinit!(p, String(str); root=dicttype()))
+tryparse(io::IO; dicttype=TOMLDict) = tryparse(read(io, String); dicttype=dicttype)
+tryparse(p::Parser, io::IO; dicttype=TOMLDict) = tryparse(p, read(io, String); dicttype=dicttype)
 
 """
     ParserError

--- a/src/parser.jl
+++ b/src/parser.jl
@@ -892,7 +892,7 @@ function parse_float(l::Parser, contains_underscore)::Err{Float64}
     return v
 end
 
-function parse_int(l::Parser, contains_underscore, base=nothing)::Err{Int64}
+function parse_int(l::Parser{DictType}, contains_underscore, base=nothing)::Err{Int64} where {DictType <: AbstractDictType}
     s = take_string_or_substring(l, contains_underscore)
     v = try
         Base.parse(Int64, s; base=base)

--- a/src/parser.jl
+++ b/src/parser.jl
@@ -944,7 +944,7 @@ function parse_datetime(l::Parser{DictType}) where {DictType <: AbstractDictType
     year in 0:9999 || return ParserError{DictType}(ErrParsingDateTime)
 
     # Month
-    accept(l, '-') || return ParserError{DictType(ErrParsingDateTime)
+    accept(l, '-') || return ParserError{DictType}(ErrParsingDateTime)
     set_marker!(l)
     @try accept_two(l, isdigit)
     month = parse_int(l, false)

--- a/src/parser.jl
+++ b/src/parser.jl
@@ -438,7 +438,7 @@ take_substring(l::Parser) = SubString(l.str, l.marker:(l.prevpos-1))
 
 # Driver, keeps parsing toplevel until we either get
 # a `ParserError` or eof.
-function parse(l::Parser)::TD
+function parse(l::Parser)
     v = tryparse(l)
     v isa ParserError && throw(v)
     return v

--- a/src/parser.jl
+++ b/src/parser.jl
@@ -267,8 +267,8 @@ mutable struct ParserError{DictType <: AbstractDictType} <: Exception
     pos       ::Union{Int,      Nothing} # position of parser when
     table     ::Union{DictType, Nothing} # result parsed until error
 end
-ParserError(type, data) = ParserError(type, data, nothing, nothing, nothing, nothing, nothing, nothing)
-ParserError(type) = ParserError(type, nothing)
+ParserError{DictType}(type, data) where {DictType <: AbstractDictType} = ParserError{DictType}(type, data, nothing, nothing, nothing, nothing, nothing, nothing)
+ParserError{DictType}(type) where {DictType <: AbstractDictType} = ParserError{DictType}(type, nothing)
 # Defining these below can be useful when debugging code that erroneously returns a
 # ParserError because you get a stacktrace to where the ParserError was created
 #ParserError(type) = error(type)

--- a/test/dicttype.jl
+++ b/test/dicttype.jl
@@ -1,5 +1,4 @@
 using TOML, Test
-using TOML: ParserError
 
 @testset "TOML.(try)parse(file) entrypoints with dicttype" begin
     dicttype = Test.IdDict{String,Any}
@@ -14,37 +13,37 @@ using TOML: ParserError
           TOML.parse(IOBuffer(str); dicttype=dicttype) ==
           TOML.parse(p, str; dicttype=dicttype) == TOML.parse(p, SubString(str); dicttype=dicttype) ==
           TOML.parse(p, IOBuffer(str); dicttype=dicttype) == dict
-    @test_throws ParserError TOML.parse(invalid_str; dicttype=dicttype)
-    @test_throws ParserError TOML.parse(SubString(invalid_str); dicttype=dicttype)
-    @test_throws ParserError TOML.parse(IOBuffer(invalid_str); dicttype=dicttype)
-    @test_throws ParserError TOML.parse(p, invalid_str; dicttype=dicttype)
-    @test_throws ParserError TOML.parse(p, SubString(invalid_str); dicttype=dicttype)
-    @test_throws ParserError TOML.parse(p, IOBuffer(invalid_str); dicttype=dicttype)
+    @test_throws TOML.ParserError TOML.parse(invalid_str; dicttype=dicttype)
+    @test_throws TOML.ParserError TOML.parse(SubString(invalid_str); dicttype=dicttype)
+    @test_throws TOML.ParserError TOML.parse(IOBuffer(invalid_str); dicttype=dicttype)
+    @test_throws TOML.ParserError TOML.parse(p, invalid_str; dicttype=dicttype)
+    @test_throws TOML.ParserError TOML.parse(p, SubString(invalid_str); dicttype=dicttype)
+    @test_throws TOML.ParserError TOML.parse(p, IOBuffer(invalid_str); dicttype=dicttype)
     @test_throws MethodError TOML.parse(str; dicttype=invalid_dicttype) 
     # TOML.tryparse
     @test TOML.tryparse(str; dicttype=dicttype) == TOML.tryparse(SubString(str); dicttype=dicttype) ==
           TOML.tryparse(IOBuffer(str); dicttype=dicttype) ==
           TOML.tryparse(p, str; dicttype=dicttype) == TOML.tryparse(p, SubString(str); dicttype=dicttype) ==
           TOML.tryparse(p, IOBuffer(str); dicttype=dicttype) == dict
-    @test TOML.tryparse(invalid_str) isa ParserError
-    @test TOML.tryparse(SubString(invalid_str)) isa ParserError
-    @test TOML.tryparse(IOBuffer(invalid_str)) isa ParserError
-    @test TOML.tryparse(p, invalid_str) isa ParserError
-    @test TOML.tryparse(p, SubString(invalid_str)) isa ParserError
-    @test TOML.tryparse(p, IOBuffer(invalid_str)) isa ParserError
+    @test TOML.tryparse(invalid_str; dicttype=dicttype) isa TOML.ParserError
+    @test TOML.tryparse(SubString(invalid_str); dicttype=dicttype) isa TOML.ParserError
+    @test TOML.tryparse(IOBuffer(invalid_str); dicttype=dicttype) isa TOML.ParserError
+    @test TOML.tryparse(p, invalid_str; dicttype=dicttype) isa TOML.ParserError
+    @test TOML.tryparse(p, SubString(invalid_str); dicttype=dicttype) isa TOML.ParserError
+    @test TOML.tryparse(p, IOBuffer(invalid_str); dicttype=dicttype) isa TOML.ParserError
     # TOML.parsefile
     @test TOML.parsefile(path; dicttype=dicttype) == TOML.parsefile(SubString(path); dicttype=dicttype) ==
           TOML.parsefile(p, path; dicttype=dicttype) == TOML.parsefile(p, SubString(path); dicttype=dicttype) == dict
-    @test_throws ParserError TOML.parsefile(invalid_path)
-    @test_throws ParserError TOML.parsefile(SubString(invalid_path))
-    @test_throws ParserError TOML.parsefile(p, invalid_path)
-    @test_throws ParserError TOML.parsefile(p, SubString(invalid_path))
+    @test_throws TOML.ParserError TOML.parsefile(invalid_path; dicttype=dicttype)
+    @test_throws TOML.ParserError TOML.parsefile(SubString(invalid_path); dicttype=dicttype)
+    @test_throws TOML.ParserError TOML.parsefile(p, invalid_path; dicttype=dicttype)
+    @test_throws TOML.ParserError TOML.parsefile(p, SubString(invalid_path); dicttype=dicttype)
     @test_throws MethodError TOML.parsefile(path; dicttype=invalid_dicttype) 
     # TOML.tryparsefile
     @test TOML.tryparsefile(path; dicttype=dicttype) == TOML.tryparsefile(SubString(path); dicttype=dicttype) ==
           TOML.tryparsefile(p, path; dicttype=dicttype) == TOML.tryparsefile(p, SubString(path); dicttype=dicttype) == dict
-    @test TOML.tryparsefile(invalid_path) isa ParserError
-    @test TOML.tryparsefile(SubString(invalid_path)) isa ParserError
-    @test TOML.tryparsefile(p, invalid_path) isa ParserError
-    @test TOML.tryparsefile(p, SubString(invalid_path)) isa ParserError
+    @test TOML.tryparsefile(invalid_path; dicttype=dicttype) isa TOML.ParserError
+    @test TOML.tryparsefile(SubString(invalid_path); dicttype=dicttype) isa TOML.ParserError
+    @test TOML.tryparsefile(p, invalid_path; dicttype=dicttype) isa TOML.ParserError
+    @test TOML.tryparsefile(p, SubString(invalid_path); dicttype=dicttype) isa TOML.ParserError
 end

--- a/test/dicttype.jl
+++ b/test/dicttype.jl
@@ -1,0 +1,50 @@
+using TOML, Test
+using TOML: ParserError
+
+@testset "TOML.(try)parse(file) entrypoints with dicttype" begin
+    dicttype = Test.IdDict{String,Any}
+    invalid_dicttype = Test.IdDict{Any, Any}
+    dict = dicttype("a" => 1)
+    str = "a = 1"; invalid_str = "a"
+    path, io = mktemp(); write(io, str); close(io)
+    invalid_path, io = mktemp(); write(io, invalid_str); close(io)
+    p = TOML.Parser()
+    # TOML.parse
+    @test TOML.parse(str; dicttype=dicttype) == TOML.parse(SubString(str); dicttype=dicttype) ==
+          TOML.parse(IOBuffer(str); dicttype=dicttype) ==
+          TOML.parse(p, str; dicttype=dicttype) == TOML.parse(p, SubString(str); dicttype=dicttype) ==
+          TOML.parse(p, IOBuffer(str); dicttype=dicttype) == dict
+    @test_throws ParserError TOML.parse(invalid_str; dicttype=dicttype)
+    @test_throws ParserError TOML.parse(SubString(invalid_str); dicttype=dicttype)
+    @test_throws ParserError TOML.parse(IOBuffer(invalid_str); dicttype=dicttype)
+    @test_throws ParserError TOML.parse(p, invalid_str; dicttype=dicttype)
+    @test_throws ParserError TOML.parse(p, SubString(invalid_str); dicttype=dicttype)
+    @test_throws ParserError TOML.parse(p, IOBuffer(invalid_str); dicttype=dicttype)
+    @test_throws MethodError TOML.parse(str; dicttype=invalid_dicttype) 
+    # TOML.tryparse
+    @test TOML.tryparse(str; dicttype=dicttype) == TOML.tryparse(SubString(str); dicttype=dicttype) ==
+          TOML.tryparse(IOBuffer(str); dicttype=dicttype) ==
+          TOML.tryparse(p, str; dicttype=dicttype) == TOML.tryparse(p, SubString(str); dicttype=dicttype) ==
+          TOML.tryparse(p, IOBuffer(str); dicttype=dicttype) == dict
+    @test TOML.tryparse(invalid_str) isa ParserError
+    @test TOML.tryparse(SubString(invalid_str)) isa ParserError
+    @test TOML.tryparse(IOBuffer(invalid_str)) isa ParserError
+    @test TOML.tryparse(p, invalid_str) isa ParserError
+    @test TOML.tryparse(p, SubString(invalid_str)) isa ParserError
+    @test TOML.tryparse(p, IOBuffer(invalid_str)) isa ParserError
+    # TOML.parsefile
+    @test TOML.parsefile(path; dicttype=dicttype) == TOML.parsefile(SubString(path); dicttype=dicttype) ==
+          TOML.parsefile(p, path; dicttype=dicttype) == TOML.parsefile(p, SubString(path); dicttype=dicttype) == dict
+    @test_throws ParserError TOML.parsefile(invalid_path)
+    @test_throws ParserError TOML.parsefile(SubString(invalid_path))
+    @test_throws ParserError TOML.parsefile(p, invalid_path)
+    @test_throws ParserError TOML.parsefile(p, SubString(invalid_path))
+    @test_throws MethodError TOML.parsefile(path; dicttype=invalid_dicttype) 
+    # TOML.tryparsefile
+    @test TOML.tryparsefile(path; dicttype=dicttype) == TOML.tryparsefile(SubString(path); dicttype=dicttype) ==
+          TOML.tryparsefile(p, path; dicttype=dicttype) == TOML.tryparsefile(p, SubString(path); dicttype=dicttype) == dict
+    @test TOML.tryparsefile(invalid_path) isa ParserError
+    @test TOML.tryparsefile(SubString(invalid_path)) isa ParserError
+    @test TOML.tryparsefile(p, invalid_path) isa ParserError
+    @test TOML.tryparsefile(p, SubString(invalid_path)) isa ParserError
+end

--- a/test/parse.jl
+++ b/test/parse.jl
@@ -1,5 +1,4 @@
 using TOML, Test
-using TOML: ParserError
 
 @testset "TOML.(try)parse(file) entrypoints" begin
     dict = Dict{String,Any}("a" => 1)
@@ -12,35 +11,35 @@ using TOML: ParserError
           TOML.parse(IOBuffer(str)) ==
           TOML.parse(p, str) == TOML.parse(p, SubString(str)) ==
           TOML.parse(p, IOBuffer(str)) == dict
-    @test_throws ParserError TOML.parse(invalid_str)
-    @test_throws ParserError TOML.parse(SubString(invalid_str))
-    @test_throws ParserError TOML.parse(IOBuffer(invalid_str))
-    @test_throws ParserError TOML.parse(p, invalid_str)
-    @test_throws ParserError TOML.parse(p, SubString(invalid_str))
-    @test_throws ParserError TOML.parse(p, IOBuffer(invalid_str))
+    @test_throws TOML.ParserError TOML.parse(invalid_str)
+    @test_throws TOML.ParserError TOML.parse(SubString(invalid_str))
+    @test_throws TOML.ParserError TOML.parse(IOBuffer(invalid_str))
+    @test_throws TOML.ParserError TOML.parse(p, invalid_str)
+    @test_throws TOML.ParserError TOML.parse(p, SubString(invalid_str))
+    @test_throws TOML.ParserError TOML.parse(p, IOBuffer(invalid_str))
     # TOML.tryparse
     @test TOML.tryparse(str) == TOML.tryparse(SubString(str)) ==
           TOML.tryparse(IOBuffer(str)) ==
           TOML.tryparse(p, str) == TOML.tryparse(p, SubString(str)) ==
           TOML.tryparse(p, IOBuffer(str)) == dict
-    @test TOML.tryparse(invalid_str) isa ParserError
-    @test TOML.tryparse(SubString(invalid_str)) isa ParserError
-    @test TOML.tryparse(IOBuffer(invalid_str)) isa ParserError
-    @test TOML.tryparse(p, invalid_str) isa ParserError
-    @test TOML.tryparse(p, SubString(invalid_str)) isa ParserError
-    @test TOML.tryparse(p, IOBuffer(invalid_str)) isa ParserError
+    @test TOML.tryparse(invalid_str) isa TOML.ParserError
+    @test TOML.tryparse(SubString(invalid_str)) isa TOML.ParserError
+    @test TOML.tryparse(IOBuffer(invalid_str)) isa TOML.ParserError
+    @test TOML.tryparse(p, invalid_str) isa TOML.ParserError
+    @test TOML.tryparse(p, SubString(invalid_str)) isa TOML.ParserError
+    @test TOML.tryparse(p, IOBuffer(invalid_str)) isa TOML.ParserError
     # TOML.parsefile
     @test TOML.parsefile(path) == TOML.parsefile(SubString(path)) ==
           TOML.parsefile(p, path) == TOML.parsefile(p, SubString(path)) == dict
-    @test_throws ParserError TOML.parsefile(invalid_path)
-    @test_throws ParserError TOML.parsefile(SubString(invalid_path))
-    @test_throws ParserError TOML.parsefile(p, invalid_path)
-    @test_throws ParserError TOML.parsefile(p, SubString(invalid_path))
+    @test_throws TOML.ParserError TOML.parsefile(invalid_path)
+    @test_throws TOML.ParserError TOML.parsefile(SubString(invalid_path))
+    @test_throws TOML.ParserError TOML.parsefile(p, invalid_path)
+    @test_throws TOML.ParserError TOML.parsefile(p, SubString(invalid_path))
     # TOML.tryparsefile
     @test TOML.tryparsefile(path) == TOML.tryparsefile(SubString(path)) ==
           TOML.tryparsefile(p, path) == TOML.tryparsefile(p, SubString(path)) == dict
-    @test TOML.tryparsefile(invalid_path) isa ParserError
-    @test TOML.tryparsefile(SubString(invalid_path)) isa ParserError
-    @test TOML.tryparsefile(p, invalid_path) isa ParserError
-    @test TOML.tryparsefile(p, SubString(invalid_path)) isa ParserError
+    @test TOML.tryparsefile(invalid_path) isa TOML.ParserError
+    @test TOML.tryparsefile(SubString(invalid_path)) isa TOML.ParserError
+    @test TOML.tryparsefile(p, invalid_path) isa TOML.ParserError
+    @test TOML.tryparsefile(p, SubString(invalid_path)) isa TOML.ParserError
 end

--- a/test/readme.jl
+++ b/test/readme.jl
@@ -535,13 +535,13 @@ str = "odt1 = 1979-05-27T07:32:00.99999Z"
 # Julia doesn't support offset datetimes
 str = "odt2 = 1979-05-27T00:32:00-07:00"
 err = tryparse(str)
-@test_broken err isa Dict
+@test_broken err isa AbstractDict
 @test err isa Internals.ParserError
 @test err.type == Internals.ErrOffsetDateNotSupported
 
 str = "odt3 = 1979-05-27T00:32:00.999999-07:00"
 err = tryparse(str)
-@test_broken err isa Dict
+@test_broken err isa AbstractDict
 @test err isa Internals.ParserError
 @test err.type == Internals.ErrOffsetDateNotSupported
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -21,5 +21,6 @@ include("invalids.jl")
 include("error_printing.jl")
 include("print.jl")
 include("parse.jl")
+include("dicttype.jl")
 
 @inferred TOML.parse("foo = 3")

--- a/test/values.jl
+++ b/test/values.jl
@@ -1,6 +1,5 @@
 using Test
 using TOML
-using TOML: Internals
 
 function testval(s, v)
     f = "foo = $s"
@@ -15,23 +14,23 @@ function failval(s, v)
 end
 
 @testset "Numbers" begin
-    @test failval("00"                   , Internals.ErrParsingDateTime)
-    @test failval("-00"                  , Internals.ErrParsingDateTime)
-    @test failval("+00"                  , Internals.ErrParsingDateTime)
-    @test failval("00.0"                 , Internals.ErrParsingDateTime)
-    @test failval("-00.0"                , Internals.ErrParsingDateTime)
-    @test failval("+00.0"                , Internals.ErrParsingDateTime)
-    @test failval("9223372036854775808"  , Internals.ErrOverflowError)
-    @test failval("-9223372036854775809" , Internals.ErrOverflowError)
+    @test failval("00"                   , TOML.Internals.ErrParsingDateTime)
+    @test failval("-00"                  , TOML.Internals.ErrParsingDateTime)
+    @test failval("+00"                  , TOML.Internals.ErrParsingDateTime)
+    @test failval("00.0"                 , TOML.Internals.ErrParsingDateTime)
+    @test failval("-00.0"                , TOML.Internals.ErrParsingDateTime)
+    @test failval("+00.0"                , TOML.Internals.ErrParsingDateTime)
+    @test failval("9223372036854775808"  , TOML.Internals.ErrOverflowError)
+    @test failval("-9223372036854775809" , TOML.Internals.ErrOverflowError)
 
-    @test failval("0."        , Internals.ErrNoTrailingDigitAfterDot)
-    @test failval("0.e"       , Internals.ErrNoTrailingDigitAfterDot)
-    @test failval("0.E"       , Internals.ErrNoTrailingDigitAfterDot)
-    @test failval("0.0E"      , Internals.ErrGenericValueError)
-    @test failval("0.0e"      , Internals.ErrGenericValueError)
-    @test failval("0.0e-"     , Internals.ErrGenericValueError)
-    @test failval("0.0e+"     , Internals.ErrGenericValueError)
-    @test_broken failval("0.0e+00" , Internals.ErrGenericValueError)
+    @test failval("0."        , TOML.Internals.ErrNoTrailingDigitAfterDot)
+    @test failval("0.e"       , TOML.Internals.ErrNoTrailingDigitAfterDot)
+    @test failval("0.E"       , TOML.Internals.ErrNoTrailingDigitAfterDot)
+    @test failval("0.0E"      , TOML.Internals.ErrGenericValueError)
+    @test failval("0.0e"      , TOML.Internals.ErrGenericValueError)
+    @test failval("0.0e-"     , TOML.Internals.ErrGenericValueError)
+    @test failval("0.0e+"     , TOML.Internals.ErrGenericValueError)
+    @test_broken failval("0.0e+00" , TOML.Internals.ErrGenericValueError)
 
     @test testval("1.0"         , 1.0)
     @test testval("1.0e0"       , 1.0)
@@ -52,11 +51,11 @@ end
     @test testval("+1_000" , 1000  |> Int64)
     @test testval("-1_000" , -1000 |> Int64)
 
-    @test failval("0_"     , Internals.ErrUnderscoreNotSurroundedByDigits)
-    @test failval("0__0"   , Internals.ErrUnderscoreNotSurroundedByDigits)
-    @test failval("__0"    , Internals.ErrUnexpectedStartOfValue)
-    @test failval("1_0_"   , Internals.ErrTrailingUnderscoreNumber)
-    @test failval("1_0__0" , Internals.ErrUnderscoreNotSurroundedByDigits)
+    @test failval("0_"     , TOML.Internals.ErrUnderscoreNotSurroundedByDigits)
+    @test failval("0__0"   , TOML.Internals.ErrUnderscoreNotSurroundedByDigits)
+    @test failval("__0"    , TOML.Internals.ErrUnexpectedStartOfValue)
+    @test failval("1_0_"   , TOML.Internals.ErrTrailingUnderscoreNumber)
+    @test failval("1_0__0" , TOML.Internals.ErrUnderscoreNotSurroundedByDigits)
 end
 
 
@@ -64,12 +63,12 @@ end
     @test testval("true", true)
     @test testval("false", false)
 
-    @test failval("true2"  , Internals.ErrExpectedNewLineKeyValue)
-    @test failval("false2" , Internals.ErrExpectedNewLineKeyValue)
-    @test failval("talse"  , Internals.ErrGenericValueError)
-    @test failval("frue"   , Internals.ErrGenericValueError)
-    @test failval("t1"     , Internals.ErrGenericValueError)
-    @test failval("f1"     , Internals.ErrGenericValueError)
+    @test failval("true2"  , TOML.Internals.ErrExpectedNewLineKeyValue)
+    @test failval("false2" , TOML.Internals.ErrExpectedNewLineKeyValue)
+    @test failval("talse"  , TOML.Internals.ErrGenericValueError)
+    @test failval("frue"   , TOML.Internals.ErrGenericValueError)
+    @test failval("t1"     , TOML.Internals.ErrGenericValueError)
+    @test failval("f1"     , TOML.Internals.ErrGenericValueError)
 end
 
 @testset "Datetime" begin
@@ -78,31 +77,31 @@ end
     @test testval("2016-09-09T09:09:09.0Z"  , DateTime(2016 , 9 , 9 , 9 , 9 , 9))
     @test testval("2016-09-09T09:09:09.012" , DateTime(2016 , 9 , 9 , 9 , 9 , 9  , 12))
 
-    @test failval("2016-09-09T09:09:09.0+10:00"   , Internals.ErrOffsetDateNotSupported)
-    @test failval("2016-09-09T09:09:09.012-02:00" , Internals.ErrOffsetDateNotSupported)
-    @test failval("2016-09-09T09:09:09.0+10:00"   , Internals.ErrOffsetDateNotSupported)
-    @test failval("2016-09-09T09:09:09.012-02:00" , Internals.ErrOffsetDateNotSupported)
+    @test failval("2016-09-09T09:09:09.0+10:00"   , TOML.Internals.ErrOffsetDateNotSupported)
+    @test failval("2016-09-09T09:09:09.012-02:00" , TOML.Internals.ErrOffsetDateNotSupported)
+    @test failval("2016-09-09T09:09:09.0+10:00"   , TOML.Internals.ErrOffsetDateNotSupported)
+    @test failval("2016-09-09T09:09:09.012-02:00" , TOML.Internals.ErrOffsetDateNotSupported)
 
-    @test failval("2016-09-09T09:09:09.Z" , Internals.ErrParsingDateTime)
-    @test failval("2016-9-09T09:09:09Z"   , Internals.ErrParsingDateTime)
-    @test failval("2016-13-09T09:09:09Z"  , Internals.ErrParsingDateTime)
-    @test failval("2016-02-31T09:09:09Z"  , Internals.ErrParsingDateTime)
-    @test failval("2016-09-09T09:09:09x"  , Internals.ErrParsingDateTime)
-    @test failval("2016-09-09s09:09:09Z"  , Internals.ErrParsingDateTime)
-    @test failval("2016-09-09T09:09:09x"  , Internals.ErrParsingDateTime)
+    @test failval("2016-09-09T09:09:09.Z" , TOML.Internals.ErrParsingDateTime)
+    @test failval("2016-9-09T09:09:09Z"   , TOML.Internals.ErrParsingDateTime)
+    @test failval("2016-13-09T09:09:09Z"  , TOML.Internals.ErrParsingDateTime)
+    @test failval("2016-02-31T09:09:09Z"  , TOML.Internals.ErrParsingDateTime)
+    @test failval("2016-09-09T09:09:09x"  , TOML.Internals.ErrParsingDateTime)
+    @test failval("2016-09-09s09:09:09Z"  , TOML.Internals.ErrParsingDateTime)
+    @test failval("2016-09-09T09:09:09x"  , TOML.Internals.ErrParsingDateTime)
 end
 
 @testset "Time" begin
     @test testval("09:09:09.99"    , Time(9 , 9 , 9 , 99))
     @test testval("09:09:09.99999" , Time(9 , 9 , 9 , 999))
 
-    @test failval("09:09x09", Internals.ErrParsingDateTime)
+    @test failval("09:09x09", TOML.Internals.ErrParsingDateTime)
 end
 
 # TODO: Add more dedicated value tests
 
 @testset "String" begin
-    @test failval("\"foooo", Internals.ErrUnexpectedEndString)
+    @test failval("\"foooo", TOML.Internals.ErrUnexpectedEndString)
 
     #=
     Found these examples of string tests somewhere


### PR DESCRIPTION
Solution for #45. Still need to write up the docs, but you can now add `;dicttype` to all parsing functions, as long as the type specified is `<: AbstractDict{String, Any}`. I've also included tests to ensure this is working.

```julia
using TOML
using OrderedCollections

s = """
[ key1 ]
a = 1
b = 2

[ key2 ]
c = 3
d = 4
"""

toml = TOML.parse(s; dicttype=OrderedDict{String, Any})
```

Every table and sub-table in `TOML` will be an `OrderedDict{String, Any}`.